### PR TITLE
i18n set to >= 0.6

### DIFF
--- a/phraseapp-in-context-editor-ruby.gemspec
+++ b/phraseapp-in-context-editor-ruby.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.test_files = s.files.grep(%r{^(spec)/})
   s.require_paths = ["lib"]
   s.add_dependency('json', '~> 1.8')
-  s.add_dependency('i18n', '~> 0.7')
+  s.add_dependency('i18n', '>= 0.6')
   s.add_dependency('phraseapp-ruby', '~> 1.2.7')
   s.add_development_dependency('rspec', '~> 3.2')
   s.add_development_dependency('webmock', '~> 1.21')


### PR DESCRIPTION
Our app is still on rails `4.1.14.2` which has i18n on `~> 0.6` so I just lowered the dependency. (update to rails 4.2.6 is planned but to time consuming by now) 

Seems to work nicely on our staging system which we use for the in context editor. Maybe this will help other rails projects which are also lacking behind. 