### PR TITLE
use RequestStore instead of Thread[:current]

### DIFF
--- a/lib/phraseapp-in-context-editor-ruby.rb
+++ b/lib/phraseapp-in-context-editor-ruby.rb
@@ -1,5 +1,6 @@
 # -*- encoding : utf-8 -*-
 require 'phraseapp-ruby'
+require 'request_store'
 
 module PhraseApp
   module InContextEditor
@@ -7,11 +8,11 @@ module PhraseApp
 
     class << self
       def config
-        Thread.current[:phraseapp_config] ||= PhraseApp::InContextEditor::Config.new
+        RequestStore.store[:phraseapp_config] ||= PhraseApp::InContextEditor::Config.new
       end
 
       def config=(value)
-        Thread.current[:phraseapp_config] = value
+        RequestStore.store[:phraseapp_config] = value
       end
 
       def backend

--- a/lib/phraseapp-in-context-editor-ruby/key_names_cache.rb
+++ b/lib/phraseapp-in-context-editor-ruby/key_names_cache.rb
@@ -46,7 +46,7 @@ module PhraseApp
       end
 
       def cache
-        Thread.current[:phraseapp_cache] ||= PhraseApp::InContextEditor::Cache.new
+        RequestStore.store[:phraseapp_cache] ||= PhraseApp::InContextEditor::Cache.new
       end
     end
   end

--- a/phraseapp-in-context-editor-ruby.gemspec
+++ b/phraseapp-in-context-editor-ruby.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   end
   s.add_dependency('i18n', '>= 0.6')
   s.add_dependency('phraseapp-ruby', '~> 1.3')
+  s.add_dependency('request_store', '~> 1.3')
   s.add_development_dependency('rspec', '~> 3.2')
   s.add_development_dependency('webmock', '~> 1.21')
   s.add_development_dependency('vcr', '~> 2.9')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,7 @@ RSpec.configure do |config|
 
   config.after(:each) do |example|
     PhraseApp::InContextEditor::Config.reset_to_defaults!
-    Thread.current[:phraseapp_config] = nil
+    RequestStore.store[:phraseapp_config] = nil
   end
 end
 


### PR DESCRIPTION
Use `RequestStore` (https://github.com/steveklabnik/request_store) instead of `Thread[:current]` in order to make sure that configuration does not stick longer than we would expect in servers like Thin or Puma.