### PR TITLE
Add pa licenses yml

### DIFF
--- a/.package-licenses.yml
+++ b/.package-licenses.yml
@@ -1,0 +1,4 @@
+# Hardcoded list of gems / packages where auto detection of license fails
+# possible root keys: ruby, elm, node, go, vendor
+ruby:
+  "diff-lcs": ["MIT"] # Apache-2.0 OR GPL-2.0+ OR MIT => MIT


### PR DESCRIPTION
Add definition of license usage for 3rd party libraries (where none or multiple licenses may be detected)