### PR TITLE
Licenses: fix project name

### DIFF
--- a/config/license-decisions.yml
+++ b/config/license-decisions.yml
@@ -1,6 +1,6 @@
 ---
 - - :name_project
-  - client
+  - ice-ruby
   - :who: Sven Dunemann
     :why: short name of project
     :versions: []


### PR DESCRIPTION
used wrong project name