### PR TITLE
fix: Add origin to track different integration usage for metrics

### DIFF
--- a/lib/phraseapp-in-context-editor-ruby.rb
+++ b/lib/phraseapp-in-context-editor-ruby.rb
@@ -48,6 +48,10 @@ module PhraseApp
       def disabled?
         !config.enabled
       end
+
+      def origin
+        config.origin
+      end
     end
 
     def self.configure

--- a/lib/phraseapp-in-context-editor-ruby/config.rb
+++ b/lib/phraseapp-in-context-editor-ruby/config.rb
@@ -9,6 +9,7 @@ module PhraseApp
         backend: PhraseApp::InContextEditor::BackendService.new,
         prefix: "{{__",
         suffix: "__}}"
+        origin: "in-context-editor-ruby"
       }.freeze
 
       CONFIG_OPTIONS.each do |option, default_value|

--- a/lib/phraseapp-in-context-editor-ruby/view_helpers.rb
+++ b/lib/phraseapp-in-context-editor-ruby/view_helpers.rb
@@ -18,6 +18,7 @@ module PhraseApp
           "datacenter" => PhraseApp::InContextEditor.datacenter,
           "prefix" => PhraseApp::InContextEditor.prefix,
           "suffix" => PhraseApp::InContextEditor.suffix
+          "origin" => PhraseApp::InContextEditor.origin
         }.merge(opts)
 
         snippet = <<-EOS

--- a/spec/phraseapp-in-context-editor-ruby/view_helpers_spec.rb
+++ b/spec/phraseapp-in-context-editor-ruby/view_helpers_spec.rb
@@ -37,6 +37,12 @@ describe PhraseApp::InContextEditor::ViewHelpers do
         it { is_expected.to include("\"suffix\":\"__]]\"") }
       end
 
+      describe "origin setting" do
+        before(:each) { PhraseApp::InContextEditor.config.origin = "__]]" }
+
+        it { is_expected.to include("\"origin\":\"in-context-editor-ruby\"") }
+      end
+
       describe "overriding options" do
         let(:opts) { {prefix: "__%%"} }
         before(:each) { PhraseApp::InContextEditor.config.prefix = "__]]" }


### PR DESCRIPTION
Added `origin` to track different integration usage for metrics