### PR TITLE
feat: Add support for Ruby 3.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,11 +2,14 @@ name: Test
 on: [ push ]
 jobs:
   test:
+    strategy:
+      matrix:
+        ruby: [ 3.1, 3.2 ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@319066216501fbd5e2d568f14b7d68c19fb67a5d
         with:
-          ruby-version: '3.2'
+          ruby-version: ${{ matrix.ruby }}
       - run: bundle install
       - run: bundle exec rspec spec

--- a/phraseapp-in-context-editor-ruby.gemspec
+++ b/phraseapp-in-context-editor-ruby.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.name = "phraseapp-in-context-editor-ruby"
   s.version = "2.0.0"
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = ">= 3.2.0"
+  s.required_ruby_version = ">= 3.1.0"
   s.authors = ["Phrase"]
   s.email = ["info@phrase.com"]
   s.homepage = "https://phrase.com"


### PR DESCRIPTION
Support for Ruby 3.1 was removed in the update to the new In-Context Editor #56. Looking around the codebase, I could not find any usage of features added in [Ruby 3.2](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released). So, as far as I can tell this gem should be able to support Ruby 3.1 as well as Ruby 3.2. This PR relaxes the Ruby version requirement in the gemspec to allow installations with Ruby 3.1.