### PR TITLE
Fix Ruby 3.0 keyword argument error when ICE is enabled

### DIFF
--- a/lib/phraseapp-in-context-editor-ruby/backend_service.rb
+++ b/lib/phraseapp-in-context-editor-ruby/backend_service.rb
@@ -55,7 +55,7 @@ module PhraseApp
         key = given_key_from_args(args)
         return nil unless present?(key)
 
-        options = args[1].nil? ? {} : args[1]
+        options = options_from_args(args)
         PhraseApp::InContextEditor::Delegate::I18nDelegate.new(key, options, args)
       end
 

--- a/lib/phraseapp-in-context-editor-ruby/delegate/i18n_delegate.rb
+++ b/lib/phraseapp-in-context-editor-ruby/delegate/i18n_delegate.rb
@@ -4,7 +4,7 @@ module PhraseApp
   module InContextEditor
     module Delegate
       class I18nDelegate < Base
-        attr_accessor :key, :display_key, :options, :api_client, :fallback_keys, :original_args
+        attr_accessor :key, :display_key
 
         def initialize(key, options = {}, original_args = nil)
           @key = key
@@ -24,7 +24,7 @@ module PhraseApp
               data.send(*args, &block)
             else
               self.class.log "You tried to execute the missing method ##{args.first} on key #{@key} which is not supported. Please make sure you treat your translations as strings only."
-              original_translation = ::I18n.translate_without_phraseapp(*@original_args)
+              original_translation = ::I18n.translate_without_phraseapp(*@original_args, **@options)
               original_translation.send(*args, &block)
             end
           end

--- a/spec/phraseapp-in-context-editor-ruby/delegate/i18n_delegate_spec.rb
+++ b/spec/phraseapp-in-context-editor-ruby/delegate/i18n_delegate_spec.rb
@@ -3,12 +3,7 @@ require "phraseapp-in-context-editor-ruby"
 require "phraseapp-in-context-editor-ruby/delegate/i18n_delegate"
 
 describe PhraseApp::InContextEditor::Delegate::I18nDelegate do
-  let(:key) { "foo.bar" }
-  let(:options) { {} }
-  let(:original_args) { double }
   let(:delegate) { PhraseApp::InContextEditor::Delegate::I18nDelegate.new(key) }
-
-  subject { delegate }
 
   describe "#to_s" do
     let(:key) { "foo.bar" }
@@ -19,6 +14,7 @@ describe PhraseApp::InContextEditor::Delegate::I18nDelegate do
   end
 
   describe "#camelize" do
+    let(:key) { "foo.bar" }
     subject { delegate.camelize }
 
     it { is_expected.to be_a String }
@@ -58,6 +54,9 @@ describe PhraseApp::InContextEditor::Delegate::I18nDelegate do
   end
 
   describe "#decorated_key_name" do
+    let(:key) { "foo.bar" }
+    subject { delegate }
+
     it "should include the phrase prefix" do
       allow(PhraseApp::InContextEditor).to receive(:prefix).and_return("??")
       expect(subject.send(:decorated_key_name).start_with?("??")).to be_truthy


### PR DESCRIPTION
When the ICE is enabled and something calls a hash method on the translatable value, there is an error due to the Ruby 3.0 keyword arguments changes:
```
Failure/Error: original_translation = ::I18n.translate_without_phraseapp(*@original_args)

     ArgumentError:
       wrong number of arguments (given 2, expected 0..1)
```

Rails' Active Support [calls hash methods](https://github.com/rails/rails/blob/v7.0.8.1/activesupport/lib/active_support/number_helper/number_converter.rb#L158) on `number.format`, because it returns a hash: 
```ruby
rails c
Loading development environment (Rails 7.0.8.1)
irb(main):001:0> I18n.translate(:'number.format', locale: :en, default: {})
=> {:separator=>".", :delimiter=>",", :precision=>3, :round_mode=>"default", :significant=>false, :strip_insignificant_zeros=>false}
```

[Failed run of the new tests](https://github.com/Bilka2/phraseapp-in-context-editor-ruby/actions/runs/8969023017) before the change, [passed new tests](https://github.com/Bilka2/phraseapp-in-context-editor-ruby/actions/runs/8969070093) after the change.

#49 fixed this issue in another spot, but missed this call to `translate_without_phraseapp`.