### PR TITLE
feat: Add config option to ignore keys

### DIFF
--- a/lib/generators/phraseapp_in_context_editor/templates/phraseapp_in_context_editor.rb
+++ b/lib/generators/phraseapp_in_context_editor/templates/phraseapp_in_context_editor.rb
@@ -9,6 +9,10 @@ PhraseApp::InContextEditor.configure do |config|
   config.account_id = "<%= options[:account_id] %>"
   config.datacenter = "eu"
 
+  # Configure an array of key names that should not be handled
+  # by the In-Context-Editor.
+  # config.ignored_keys = ["number.*", "foo.bar"]
+
   # Phrase uses decorators to generate a unique identification key
   # in context of your document. However, this might result in conflicts
   # with other libraries (e.g. client-side template engines) that use a similar syntax.

--- a/lib/phraseapp-in-context-editor-ruby.rb
+++ b/lib/phraseapp-in-context-editor-ruby.rb
@@ -37,6 +37,10 @@ module PhraseApp
         config.datacenter
       end
 
+      def ignored_keys
+        config.ignored_keys
+      end
+
       def enabled=(value)
         config.enabled = value
       end

--- a/lib/phraseapp-in-context-editor-ruby/backend_service.rb
+++ b/lib/phraseapp-in-context-editor-ruby/backend_service.rb
@@ -3,8 +3,6 @@ require_relative "delegate/i18n_delegate"
 module PhraseApp
   module InContextEditor
     class BackendService
-      attr_accessor :blacklisted_keys
-
       def initialize(args = {})
         self
       end
@@ -20,7 +18,14 @@ module PhraseApp
       protected
 
       def to_be_translated_without_phraseapp?(...)
-        PhraseApp::InContextEditor.disabled? || has_been_forced_to_resolve_with_phraseapp?(...)
+        PhraseApp::InContextEditor.disabled? || ignored_key?(...) || has_been_forced_to_resolve_with_phraseapp?(...)
+      end
+
+      def ignored_key?(*args)
+        key = given_key_from_args(args)
+        PhraseApp::InContextEditor.ignored_keys.any? do |ignored_key|
+          key.to_s[/\A#{ignored_key.gsub("*", ".*")}\Z/]
+        end
       end
 
       def has_been_forced_to_resolve_with_phraseapp?(*args)

--- a/lib/phraseapp-in-context-editor-ruby/config.rb
+++ b/lib/phraseapp-in-context-editor-ruby/config.rb
@@ -9,7 +9,8 @@ module PhraseApp
         backend: PhraseApp::InContextEditor::BackendService.new,
         prefix: "{{__",
         suffix: "__}}",
-        origin: "in-context-editor-ruby"
+        origin: "in-context-editor-ruby",
+        ignored_keys: []
       }.freeze
 
       CONFIG_OPTIONS.each do |option, default_value|

--- a/lib/phraseapp-in-context-editor-ruby/version.rb
+++ b/lib/phraseapp-in-context-editor-ruby/version.rb
@@ -1,3 +1,3 @@
 module PhraseApp
-  VERSION = "2.1.0"
+  VERSION = "3.1.0"
 end

--- a/spec/phraseapp-in-context-editor-ruby/backend_service_spec.rb
+++ b/spec/phraseapp-in-context-editor-ruby/backend_service_spec.rb
@@ -113,6 +113,39 @@ describe PhraseApp::InContextEditor::BackendService do
     end
   end
 
+  describe "#ignored_key?" do
+    let(:key_name) { "bar" }
+    subject { phraseapp_service.send(:ignored_key?, key_name, scope: "foo") }
+
+    before do
+      PhraseApp::InContextEditor.config.ignored_keys = ignored_keys
+    end
+
+    context "exact key is ignored" do
+      let(:ignored_keys) { %w[foo.bar baz] }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "key with wildcard is ignored" do
+      let(:ignored_keys) { %w[foo.* baz] }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "no keys are ignored" do
+      let(:ignored_keys) { [] }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "different keys are ignored" do
+      let(:ignored_keys) { %w[baz baz.foo bar.* foo] }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
   describe "#normalized_key" do
     subject { phraseapp_service.send(:normalized_key, args) }
 


### PR DESCRIPTION
Resolves #80.

Add `config.ignored_keys` to exclude keys from being handled by the ICE.

Implementation is inspired by pre 2.0 versions of this gem, with simplified code.