### PR TITLE
fix: Adjust module name to fix semantic release bumps

### DIFF
--- a/lib/phraseapp-in-context-editor-ruby/version.rb
+++ b/lib/phraseapp-in-context-editor-ruby/version.rb
@@ -1,3 +1,3 @@
-module PhraseApp
-  VERSION = "2.1.0"
+module PhraseappInContextEditor
+  VERSION = "3.0.0"
 end

--- a/phraseapp-in-context-editor-ruby.gemspec
+++ b/phraseapp-in-context-editor-ruby.gemspec
@@ -4,7 +4,7 @@ require "./lib/phraseapp-in-context-editor-ruby/version"
 
 Gem::Specification.new do |s|
   s.name = "phraseapp-in-context-editor-ruby"
-  s.version = PhraseApp::VERSION
+  s.version = PhraseappInContextEditor::VERSION
   s.platform = Gem::Platform::RUBY
   s.required_ruby_version = ">= 3.1.0"
   s.authors = ["Phrase"]


### PR DESCRIPTION
Module name was wrongly set so the bump was not possible to do automatically.