### PR TITLE
chore(csp): add style_src_elem and connect_src to the CSP config

### DIFF
--- a/examples/demo/config/initializers/content_security_policy.rb
+++ b/examples/demo/config/initializers/content_security_policy.rb
@@ -2,7 +2,7 @@
 
 # Define an application-wide content security policy.
 # See the Securing Rails Applications Guide for more information:
-# https://guides.rubyonrails.org/security.html#content-security-policy-header
+# 📈https://guides.rubyonrails.org/security.html#content-security-policy-header
 
 Rails.application.configure do
   config.content_security_policy do |policy|
@@ -12,6 +12,8 @@ Rails.application.configure do
     policy.object_src :none
     policy.script_src :self, :https, :strict_dynamic
     policy.style_src :self, :https
+    policy.style_src_elem :self :https
+    policy.connect_src :self, :https
     # Specify URI for violation reports
     # policy.report_uri "/csp-violation-report-endpoint"
   end


### PR DESCRIPTION
### What does this PR do

This PR updates the CSP policy by adding the `style-src-elem` and `connect-src` directives.

We're using Phrase and we got a CSP violation report with these two directives. These two resources were being blocked on our side by our CSP policy because of the two missing directives:

```
https://d2bgdldl6xit7z.cloudfront.net/76953aaec4a5acefd6c2200b644d1978e827bfb0/ice/index.css
https://d2bgdldl6xit7z.cloudfront.net/76953aaec4a5acefd6c2200b644d1978e827bfb0/ice/manifest.json
```

The CSS file is currently being used here: https://github.com/phrase/react-intl-phraseapp/blob/7df79d222970305bb30a12ff68ac0af61d424267/src/functions.ts#L56

Let me know if there are further changes I should make to the PR.