### PR TITLE
chore: Add Dependabot config to exclude /examples

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directories:
+      - "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "bundler"
-    directories:
-      - "/"
+    directory: "/"
     schedule:
       interval: "weekly"
   - package-ecosystem: "npm"


### PR DESCRIPTION
Add local Dependabot config to exclude updates to `/example/demo`.